### PR TITLE
Fix region files not being written to file correctly

### DIFF
--- a/nbt.c
+++ b/nbt.c
@@ -1537,6 +1537,10 @@ int MCA_WriteRaw_File(FILE* fp, MCA* mca) {
         int newpos = (ftell(fp) >> 12) + 1;
         offsets[i] |= (newpos - current) & 0xff;
         current = newpos;
+        if((5 + size - 1) % 4096) {   // Adds padding for chunk if the chunk doesn't allign with a multiple of 4096 bytes by itself (only relevant for last chunk in regionfile)
+            fseek(fp, (((offsets[i] >> 8) + (offsets[i] & 0xFF)) << 12) - 1, SEEK_SET);
+            fputc(0, fp);
+        }
     }
     fseek(fp, 0, SEEK_SET);
     for (i = 0; i < CHUNKS_IN_REGION; i ++) {


### PR DESCRIPTION
The length of regionfiles must be a multiple of 4096 bytes. This wasn't guaranteed before.
(before regionfiles written were sometimes corrupted and minecraft coudn't open them correctly(voiding some chunks of a region))